### PR TITLE
Remove VRC Constraints Beta Notice

### DIFF
--- a/docs/Other/Benchmarks.md
+++ b/docs/Other/Benchmarks.md
@@ -391,16 +391,6 @@ However, setting the weight to 0 still makes it count for performance!
 
 VRC Constraints are components added by VRChat that will replace Unity Constraints in VRChat. They are meant to be more optimized and more feature complete versions of Unity Constraints, while still being a drop-in replacement. There is an auto conversion feature at the bottom of the VRCSDK. 
 
-
-:::caution
-
-For now VRC Constraints only exist in a Beta SDK and a Beta version of the game, and they still have some crashing issues. These might be resolved once the Update goes live. If any performance characteristics change between this Beta and the release, the numbers below will be updated.
-
-:::
-
-
-
-
 Their frame time is a lot worse in the unity editor than in game, which is why I sadly don’t have any graphs, but I do have valuable data:
 
 - VRC Constraints cost about 0.25 ms of frame time per 1000 active VRC Constraints, no matter how many sources there are.

--- a/docs/Other/Benchmarks.md
+++ b/docs/Other/Benchmarks.md
@@ -662,4 +662,4 @@ If you have other things you want me to benchmark or you think I made a mistake,
 
 
 ---
-<RightAlignedText>Last Updated: 14 July 2024 21:44:00</RightAlignedText>
+<RightAlignedText>Last Updated: 15 October 2024 14:32:00</RightAlignedText>

--- a/docs/Other/Benchmarks.md
+++ b/docs/Other/Benchmarks.md
@@ -2,7 +2,7 @@
 title: Unity/VRChat Performance Benchmarks
 sidebar_position: 0
 slug: Benchmarks
-last_edited: 2024-07-14T21:44:00.000Z
+last_edited: 2024-11-15T14:32:00.000Z
 contributors: "[Jellejurre](https://jellejurre.dev/)"
 ---
 Contributors: [Jellejurre](https://jellejurre.dev/)


### PR DESCRIPTION
Just removes this notice for VRC Constraints.
https://vrc.school/docs/Other/Benchmarks/#59ace515859342c0b58324f69473f172

![image](https://github.com/user-attachments/assets/675a51da-ba9e-4604-b577-3d6fb0b31823)
